### PR TITLE
Remove "install" when using ni

### DIFF
--- a/just/base.just
+++ b/just/base.just
@@ -58,7 +58,7 @@ alias fw := full-write
 
 # Install the Node.js dependencies
 install *args:
-    ni install {{ args }}
+    ni {{ args }}
 
 # Install the Node.js dependencies without updating the lockfile
 install-frozen:


### PR DESCRIPTION
`ni` is an alias for installing dependencies with the project specific package manager. 

When we do `ni install` we actually say `pnpm install install` which literally adds the [install](https://www.npmjs.com/package/install) package as a dependency.