### PR TITLE
fix(just): exclude node_modules from mdformat recipes

### DIFF
--- a/just/base.just
+++ b/just/base.just
@@ -120,13 +120,13 @@ alias kw := knip-write
 # Check Markdown formatting with mdformat
 [group("checks"), no-cd]
 @mdformat-check +paths=".":
-    mdformat --check {{ paths }}
+    mdformat --check --exclude "node_modules/**" {{ paths }}
 alias mc := mdformat-check
 
 # Format Markdown files with mdformat
 [group("checks"), no-cd]
 @mdformat-write +paths=".":
-    mdformat {{ paths }}
+    mdformat --exclude "node_modules/**" {{ paths }}
 alias mw := mdformat-write
 
 # Check Prettier formatting


### PR DESCRIPTION
## Summary

- Add `--exclude "node_modules/**"` to `mdformat-check` and `mdformat-write` recipes to prevent scanning Markdown files inside `node_modules/`

Closes #39